### PR TITLE
test: add new test cases for decimal rounding edge scenarios

### DIFF
--- a/tests/decimal/common/round.rs
+++ b/tests/decimal/common/round.rs
@@ -30,6 +30,8 @@ macro_rules! test_impl {
         #[case($dec!(0.33333333333333333333333333333333333333333333333333333333333333333333333333333333333333), 0, $dec!(0), $dec!(0))]
         #[case($dec!(44), 99, $dec!(44), $dec!(44))]
         #[case($dec!(1.555), 99, $dec!(1.555), $dec!(1.555))]
+        #[case($dec!(0.648), 1, $dec!(0.6), $dec!(0.6))]
+        #[case($dec!(0.648), 2, $dec!(0.65), $dec!(0.64))]
         fn test_round_512(#[case] x: $D, #[case] digits: i16, #[case] y: $D, #[case] z: $D) {
             assert_eq!(x.with_rounding_mode(RoundingMode::HalfUp).round(digits), y);
             assert_eq!(x.with_rounding_mode(RoundingMode::Down).round(digits), z);
@@ -44,6 +46,8 @@ macro_rules! test_impl {
         #[rstest(::trace)]
         #[case($dec!(-44), - 99, $dec!(-0), $dec!(-0))]
         #[case($dec!(-1.555), 99, $dec!(-1.555), $dec!(-1.555))]
+        #[case($dec!(-0.648), 1, $dec!(-0.6), $dec!(-0.7))]
+        #[case($dec!(-0.648), 2, $dec!(-0.65), $dec!(-0.65))]
         fn test_round_512_signed(#[case] x: $D, #[case] digits: i16, #[case] y: $D, #[case] z: $D) {
             assert_eq!(x.with_rounding_mode(RoundingMode::HalfUp).round(digits), y);
             assert_eq!(x.with_rounding_mode(RoundingMode::Down).round(digits), z);


### PR DESCRIPTION
The current implementation rounds one digit at a time, i.e. 0.648 -> 0.65 -> 0.7, which is incorrect.
https://github.com/neogenie/fastnum/blob/59b69596f4d70ef5f9d33b14d64e733ba2c974c1/src/decimal/dec/scale.rs#L47-L48

The pull request serves to provide counter examples without an immediate fix.