### PR TITLE
Remove `Ord` impl for all decimal types

### DIFF
--- a/src/decimal/dec/cmp.rs
+++ b/src/decimal/dec/cmp.rs
@@ -47,13 +47,17 @@ pub(crate) const fn ne<const N: usize>(lhs: &D<N>, rhs: &D<N>) -> bool {
 }
 
 #[inline]
-pub(crate) const fn cmp<const N: usize>(lhs: &D<N>, rhs: &D<N>) -> Ordering {
-    match (lhs.is_negative(), rhs.is_negative()) {
+pub(crate) const fn cmp<const N: usize>(lhs: &D<N>, rhs: &D<N>) -> Option<Ordering> {
+    if lhs.is_nan() || rhs.is_nan() {
+        return None;
+    }
+    
+    Some(match (lhs.is_negative(), rhs.is_negative()) {
         (false, true) => Ordering::Greater,
         (true, false) => Ordering::Less,
         (true, true) => cmp_magnitude(lhs, rhs).reverse(),
         (false, false) => cmp_magnitude(lhs, rhs),
-    }
+    })
 }
 
 #[inline(always)]

--- a/src/decimal/dec/impls/ord.rs
+++ b/src/decimal/dec/impls/ord.rs
@@ -5,13 +5,6 @@ use crate::decimal::Decimal;
 impl<const N: usize> PartialOrd for Decimal<N> {
     #[inline]
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        Some(std::cmp::Ord::cmp(self, rhs))
-    }
-}
-
-impl<const N: usize> Ord for Decimal<N> {
-    #[inline]
-    fn cmp(&self, rhs: &Self) -> Ordering {
         self.cmp(rhs)
     }
 }

--- a/src/decimal/dec/math/asin.rs
+++ b/src/decimal/dec/math/asin.rs
@@ -26,23 +26,24 @@ pub(crate) const fn asin<const N: usize>(x: D<N>) -> D<N> {
     }
 
     match x.cmp(&D::ONE.neg()) {
-        Ordering::Less => {
+        Some(Ordering::Less) => {
             return x.signaling_nan();
         }
-        Ordering::Equal => return Consts::FRAC_PI_2.neg(),
-        Ordering::Greater => {}
+        Some(Ordering::Equal) => return Consts::FRAC_PI_2.neg(),
+        Some(Ordering::Greater) => {},
+        None => return x.signaling_nan(),
     }
 
     match x.cmp(&D::ONE) {
-        Ordering::Less => {}
-        Ordering::Equal => {
+        Some(Ordering::Less) => {}
+        Some(Ordering::Equal) => {
             return Consts::FRAC_PI_2;
         }
-        Ordering::Greater => {
+        Some(Ordering::Greater) => {
             return x.signaling_nan();
         }
+        None => return x.signaling_nan(),
     }
-
     asin_reduction(x)
 }
 

--- a/src/decimal/dec/math/atan.rs
+++ b/src/decimal/dec/math/atan.rs
@@ -22,21 +22,23 @@ pub(crate) const fn atan<const N: usize>(x: D<N>) -> D<N> {
     }
 
     match x.cmp(&D::ONE.neg()) {
-        Ordering::Less => {
+        Some(Ordering::Less) => {
             return x.signaling_nan();
         }
-        Ordering::Equal => return Consts::FRAC_PI_4.neg(),
-        Ordering::Greater => {}
+        Some(Ordering::Equal) => return Consts::FRAC_PI_4.neg(),
+        Some(Ordering::Greater) => {},
+        None => return x.signaling_nan(),
     }
 
     match x.cmp(&D::ONE) {
-        Ordering::Less => {}
-        Ordering::Equal => {
+        Some(Ordering::Less) => {}
+        Some(Ordering::Equal) => {
             return Consts::FRAC_PI_4;
         }
-        Ordering::Greater => {
+        Some(Ordering::Greater) => {
             return x.signaling_nan();
         }
+        None => return x.signaling_nan(),
     }
 
     let x2 = mul(x, x);

--- a/src/decimal/dec/math/atan2.rs
+++ b/src/decimal/dec/math/atan2.rs
@@ -13,11 +13,12 @@ type D<const N: usize> = Decimal<N>;
 #[inline]
 pub(crate) const fn atan2<const N: usize>(y: D<N>, x: D<N>) -> D<N> {
     match (cmp(&x, &D::ZERO), cmp(&y, &D::ZERO)) {
-        (Equal, Equal) => x.compound(&y).signaling_nan(),
-        (Greater, _) => atan(div(y, x)),
-        (Less, Greater | Equal) => add(atan(div(y, x)), D::PI),
-        (Less, Less) => sub(atan(div(y, x)), D::PI),
-        (Equal, Greater) => D::FRAC_PI_2,
-        (Equal, Less) => D::FRAC_PI_2.neg(),
+        (Some(Equal), Some(Equal)) => x.compound(&y).signaling_nan(),
+        (Some(Greater), _) => atan(div(y, x)),
+        (Some(Less), Some(Greater) | Some(Equal)) => add(atan(div(y, x)), D::PI),
+        (Some(Less), Some(Less)) => sub(atan(div(y, x)), D::PI),
+        (Some(Equal), Some(Greater)) => D::FRAC_PI_2,
+        (Some(Equal), Some(Less)) => D::FRAC_PI_2.neg(),
+        _ => y.signaling_nan(),
     }
 }

--- a/src/decimal/dec/math/ln.rs
+++ b/src/decimal/dec/math/ln.rs
@@ -44,9 +44,10 @@ pub(crate) const fn ln_1p<const N: usize>(x: D<N>) -> D<N> {
 #[inline]
 const fn argument_reduction<const N: usize>(x: D<N>) -> D<N> {
     match x.cmp(&D::TWO) {
-        Ordering::Less => taylor_series(x),
-        Ordering::Equal => Consts::LN_2,
-        Ordering::Greater => mul(D::TWO, argument_reduction(sqrt(x))),
+        Some(Ordering::Less) => taylor_series(x),
+        Some(Ordering::Equal) => Consts::LN_2,
+        Some(Ordering::Greater) => mul(D::TWO, argument_reduction(sqrt(x))),
+        None => x.signaling_nan(),
     }
 }
 

--- a/src/decimal/dec/math/log2.rs
+++ b/src/decimal/dec/math/log2.rs
@@ -37,9 +37,10 @@ pub(crate) const fn log2<const N: usize>(x: D<N>) -> D<N> {
 const fn log2_reduce<const N: usize>(x: D<N>) -> D<N> {
     // TODO: remove iteration by direct 2^N
     match x.cmp(&D::TWO) {
-        Ordering::Less => log2_impl(x),
-        Ordering::Equal => D::ONE,
-        Ordering::Greater => add(log2_reduce(div(x, D::TWO)), D::ONE),
+        Some(Ordering::Less) => log2_impl(x),
+        Some(Ordering::Equal) => D::ONE,
+        Some(Ordering::Greater) => add(log2_reduce(div(x, D::TWO)), D::ONE),
+        None => x.signaling_nan(),
     }
 }
 

--- a/src/decimal/dec/math/sin.rs
+++ b/src/decimal/dec/math/sin.rs
@@ -43,13 +43,14 @@ const fn sin_abs<const N: usize>(d: D<N>) -> D<N> {
     debug_assert!(x.lt(&Consts::TAU));
 
     match x.cmp(&Consts::PI) {
-        Ordering::Less => sin_less_pi(x),
-        Ordering::Equal => D::ZERO.with_ctx(d.context()),
-        Ordering::Greater => {
+        Some(Ordering::Less) => sin_less_pi(x),
+        Some(Ordering::Equal) => D::ZERO.with_ctx(d.context()),
+        Some(Ordering::Greater) => {
             // We can further reduce x, so it is between 0..π using the identity:
             // sin(x)=-sin(x-π) for x≥π.
             sin_less_pi(sub(x, Consts::PI)).neg()
         }
+        None => d.signaling_nan(),
     }
 }
 

--- a/src/decimal/udec/impls/ord.rs
+++ b/src/decimal/udec/impls/ord.rs
@@ -5,13 +5,6 @@ use crate::decimal::UnsignedDecimal;
 impl<const N: usize> PartialOrd for UnsignedDecimal<N> {
     #[inline]
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        Some(std::cmp::Ord::cmp(self, rhs))
-    }
-}
-
-impl<const N: usize> Ord for UnsignedDecimal<N> {
-    #[inline]
-    fn cmp(&self, rhs: &Self) -> Ordering {
         self.cmp(rhs)
     }
 }

--- a/tests/decimal/common/cmp.rs
+++ b/tests/decimal/common/cmp.rs
@@ -8,7 +8,6 @@ macro_rules! test_impl {
     (UNSIGNED: $bits: tt, $dec: ident, $D: ident) => {
         mod $dec {
             use rstest::*;
-            use std::cmp::{max, min};
             use fastnum::{$dec, $D};
 
             super::test_impl!(COMMON:: $bits, $dec, $D, THIS);
@@ -18,7 +17,6 @@ macro_rules! test_impl {
     (SIGNED: $bits: tt, $dec: ident, $D: ident) => {
         mod $dec {
             use rstest::*;
-            use std::cmp::{max, min};
             use fastnum::{$dec, $D};
 
             super::test_impl!(COMMON:: $bits, $dec, $D, THIS);
@@ -43,8 +41,8 @@ macro_rules! test_impl {
             assert!(a <= b);
             assert!(b > a);
             assert!(b >= a);
-            assert_eq!(max(a, b), b);
-            assert_eq!(min(a, b), a)
+            assert_eq!(a.max(b), b);
+            assert_eq!(a.min(b), a)
         }
     };
     (UNSIGNED:: 512, $dec: ident, $D: ident, THIS) => {
@@ -68,8 +66,8 @@ macro_rules! test_impl {
             assert!(a <= b);
             assert!(b > a);
             assert!(b >= a);
-            assert_eq!(max(a, b), b);
-            assert_eq!(min(a, b), a)
+            assert_eq!(a.max(b), b);
+            assert_eq!(a.min(b), a)
         }
     };
 
@@ -96,8 +94,8 @@ macro_rules! test_impl {
             assert!(a <= b);
             assert!(b > a);
             assert!(b >= a);
-            assert_eq!(max(a, b), b);
-            assert_eq!(min(a, b), a)
+            assert_eq!(a.max(b), b);
+            assert_eq!(a.min(b), a)
         }
     };
     (UNSIGNED:: 256, $dec: ident, $D: ident, THIS) => {
@@ -126,8 +124,8 @@ macro_rules! test_impl {
             assert!(a <= b);
             assert!(b > a);
             assert!(b >= a);
-            assert_eq!(max(a, b), b);
-            assert_eq!(min(a, b), a)
+            assert_eq!(a.max(b), b);
+            assert_eq!(a.min(b), a)
         }
     };
 
@@ -168,8 +166,8 @@ macro_rules! test_impl {
             assert!(a <= b);
             assert!(b > a);
             assert!(b >= a);
-            assert_eq!(max(a, b), b);
-            assert_eq!(min(a, b), a)
+            assert_eq!(a.max(b), b);
+            assert_eq!(a.min(b), a)
         }
 
         #[rstest(::trace)]
@@ -252,8 +250,8 @@ macro_rules! test_impl {
             assert!(a < b);
             assert!(b > a);
             assert!(b >= a);
-            assert_eq!(max(a, b), b);
-            assert_eq!(min(a, b), a)
+            assert_eq!(a.max(b), b);
+            assert_eq!(a.min(b), a)
         }
 
         #[rstest(::trace)]


### PR DESCRIPTION
while using this crate I found it confusing that a decimal type had `Ord` implemented, as it's unclear to me what comparing `NaN` to some other value would result in.

For example both `f64` and `f32` do not implement `Ord` but just `PartialOrd`. I think this is possibly more correct.