### PR TITLE
add public constant functions for converts Decimal and UnsignedDecimal from/to Rust's primitive numeric types

### DIFF
--- a/src/decimal/dec/impls/from.rs
+++ b/src/decimal/dec/impls/from.rs
@@ -2,30 +2,44 @@ use crate::decimal::{dec::parse, Decimal};
 
 type D<const N: usize> = Decimal<N>;
 
-macro_rules! from_impl {
-    ($n: ident, $ty: ty) => {
-        impl<const N: usize> From<$ty> for D<N> {
-            #[inline]
-            fn from(n: $ty) -> Self {
-                parse::$n(n)
+macro_rules! from_num_impls {
+    ($($name:ident $num:ty,)*) => {
+        $(
+            impl<const N: usize> From<$num> for D<N> {
+                #[inline]
+                fn from(n: $num) -> Self {
+                    parse::$name(n)
+                }
             }
+        )*
+
+        impl<const N: usize> D<N> {
+            $(
+                #[inline]
+                #[doc = concat!("Converts [`", stringify!($num), "`] to [Decimal].")]
+                pub const fn $name(n: $num) -> Self {
+                    parse::$name(n)
+                }
+            )*
         }
     };
 }
 
-from_impl!(from_u8, u8);
-from_impl!(from_u16, u16);
-from_impl!(from_u32, u32);
-from_impl!(from_u64, u64);
-from_impl!(from_u128, u128);
-from_impl!(from_usize, usize);
+from_num_impls!(
+    from_u8 u8,
+    from_u16 u16,
+    from_u32 u32,
+    from_u64 u64,
+    from_u128 u128,
+    from_usize usize,
 
-from_impl!(from_i8, i8);
-from_impl!(from_i16, i16);
-from_impl!(from_i32, i32);
-from_impl!(from_i64, i64);
-from_impl!(from_i128, i128);
-from_impl!(from_isize, isize);
+    from_i8 i8,
+    from_i16 i16,
+    from_i32 i32,
+    from_i64 i64,
+    from_i128 i128,
+    from_isize isize,
 
-from_impl!(from_f32, f32);
-from_impl!(from_f64, f64);
+    from_f32 f32,
+    from_f64 f64,
+);

--- a/src/decimal/dec/impls/to.rs
+++ b/src/decimal/dec/impls/to.rs
@@ -4,43 +4,68 @@ use crate::decimal::{dec::convert, Decimal};
 
 type D<const N: usize> = Decimal<N>;
 
-impl<const N: usize> From<D<N>> for f32 {
-    #[inline]
-    fn from(d: D<N>) -> Self {
-        convert::to_f32(d)
-    }
-}
+macro_rules! try_to_int_impls {
+    ($($name:ident $int:ty,)*) => {
+        $(
+            impl<const N: usize> TryFrom<D<N>> for $int {
+                type Error = IntErrorKind;
 
-impl<const N: usize> From<D<N>> for f64 {
-    #[inline]
-    fn from(d: D<N>) -> Self {
-        convert::to_f64(d)
-    }
-}
-
-macro_rules! try_to_impl {
-    ($to_int: ident, $int: ty) => {
-        impl<const N: usize> TryFrom<D<N>> for $int {
-            type Error = IntErrorKind;
-
-            #[inline]
-            fn try_from(d: D<N>) -> Result<Self, Self::Error> {
-                convert::$to_int(d)
+                #[inline]
+                fn try_from(d: D<N>) -> Result<$int, Self::Error> {
+                    convert::$name(d)
+                }
             }
+        )*
+
+        impl<const N: usize> D<N> {
+            $(
+                #[inline]
+                #[doc = concat!("Converts [Decimal] into [`", stringify!($int), "`].")]
+                pub const fn $name(self) -> Result<$int, IntErrorKind> {
+                    convert::$name(self)
+                }
+            )*
         }
     };
 }
 
-try_to_impl!(to_usize, usize);
-try_to_impl!(to_u8, u8);
-try_to_impl!(to_u16, u16);
-try_to_impl!(to_u32, u32);
-try_to_impl!(to_u64, u64);
-try_to_impl!(to_u128, u128);
+try_to_int_impls!(
+    to_u8 u8,
+    to_u16 u16,
+    to_u32 u32,
+    to_u64 u64,
+    to_u128 u128,
+    to_usize usize,
 
-try_to_impl!(to_isize, isize);
-try_to_impl!(to_i8, i8);
-try_to_impl!(to_i16, i16);
-try_to_impl!(to_i32, i32);
-try_to_impl!(to_i64, i64);
-try_to_impl!(to_i128, i128);
+    to_i8 i8,
+    to_i16 i16,
+    to_i32 i32,
+    to_i64 i64,
+    to_i128 i128,
+    to_isize isize,
+);
+
+impl<const N: usize> From<D<N>> for f32 {
+    #[inline]
+    fn from(d: D<N>) -> f32 {
+        convert::to_f32(d)
+    }
+}
+impl<const N: usize> From<D<N>> for f64 {
+    #[inline]
+    fn from(d: D<N>) -> f64 {
+        convert::to_f64(d)
+    }
+}
+
+impl<const N: usize> D<N> {
+    /// Converts [Decimal] into [`f32`].
+    pub const fn to_f32(self) -> f32 {
+        convert::to_f32(self)
+    }
+
+    /// Converts [Decimal] into [`f64`].
+    pub const fn to_f64(self) -> f64 {
+        convert::to_f64(self)
+    }
+}

--- a/src/decimal/dec/impls/to.rs
+++ b/src/decimal/dec/impls/to.rs
@@ -1,6 +1,6 @@
 use core::num::IntErrorKind;
 
-use crate::decimal::{dec::convert, Decimal};
+use crate::decimal::{dec::convert, Decimal, UnsignedDecimal, DecimalError};
 
 type D<const N: usize> = Decimal<N>;
 
@@ -67,5 +67,10 @@ impl<const N: usize> D<N> {
     /// Converts [Decimal] into [`f64`].
     pub const fn to_f64(self) -> f64 {
         convert::to_f64(self)
+    }
+
+    /// Converts [Decimal] into [UnsignedDecimal].
+    pub const fn to_unsigned_decimal(self) -> Result<UnsignedDecimal<N>, DecimalError> {
+        UnsignedDecimal::from_decimal(self)
     }
 }

--- a/src/decimal/udec/impls/from.rs
+++ b/src/decimal/udec/impls/from.rs
@@ -14,68 +14,99 @@ impl<const N: usize> TryFrom<D<N>> for UD<N> {
         Ok(Self::new(d))
     }
 }
+impl<const N: usize> UD<N> {
+    /// Converts from [Decimal] to [UnsignedDecimal].
+    pub const fn from_decimal(d: D<N>) -> Result<Self, DecimalError> {
+        if d.is_negative() {
+            return Err(DecimalError::Invalid);
+        }
+        Ok(Self::new(d))
+    }
+}
 
 impl<const N: usize> From<UD<N>> for D<N> {
     #[inline]
-    fn from(d: UD<N>) -> Self {
-        d.0
+    fn from(ud: UD<N>) -> Self {
+        ud.0
+    }
+}
+impl<const N: usize> D<N> {
+    /// Converts from [UnsignedDecimal] to [Decimal].
+    pub const fn from_unsigned_decimal(ud: UD<N>) -> Self {
+        ud.0
     }
 }
 
 macro_rules! from_uint {
-    ($($uint: tt),*) => {
+    ($($name:ident $uint:ty,)*) => {
         $(
             impl<const N: usize> From<$uint> for UD<N> {
                 #[inline]
-                fn from(int: $uint) -> Self {
-                    Self::new(Decimal::from(int))
+                fn from(n: $uint) -> Self {
+                    Self::new(D::from(n))
                 }
             }
         )*
+
+        impl<const N: usize> UD<N> {
+            $(
+                #[doc = concat!("Converts [`", stringify!($uint), "`] to [UnsignedDecimal].")]
+                pub const fn $name(n: $uint) -> Self {
+                    Self::new(D::$name(n))
+                }
+            )*
+        }
     }
 }
 
-macro_rules! try_from_int {
-    ($($int: tt),*) => {
+macro_rules! try_from_num {
+    ($($name:ident $num:ty,)*) => {
         $(
-            impl<const N: usize> TryFrom<$int> for UD<N> {
+            impl<const N: usize> TryFrom<$num> for UD<N> {
                 type Error = ParseError;
 
                 #[inline]
-                fn try_from(int: $int) -> Result<Self, Self::Error> {
-                    if int.is_negative() {
+                fn try_from(n: $num) -> Result<Self, Self::Error> {
+                    if n < (0 as $num) {
                         return Err(ParseError::Signed);
                     }
-                    Ok(Self::new(Decimal::from(int)))
+                    Ok(Self::new(D::from(n)))
                 }
             }
         )*
-    }
-}
 
-from_uint!(u8, u16, u32, u64, u128, usize);
-try_from_int!(i8, i16, i32, i64, i128, isize);
-
-impl<const N: usize> TryFrom<f32> for UD<N> {
-    type Error = ParseError;
-
-    #[inline]
-    fn try_from(n: f32) -> Result<Self, Self::Error> {
-        if n.is_sign_negative() {
-            return Err(ParseError::Signed);
+        impl<const N: usize> UD<N> {
+            $(
+                #[doc = concat!("Converts [`", stringify!($num), "`] to [UnsignedDecimal].")]
+                pub const fn $name(n: $num) -> Result<Self, ParseError> {
+                    if n < (0 as $num) {
+                        return Err(ParseError::Signed);
+                    }
+                    Ok(Self::new(D::$name(n)))
+                }
+            )*
         }
-        Ok(Self::new(Decimal::from(n)))
     }
 }
 
-impl<const N: usize> TryFrom<f64> for UD<N> {
-    type Error = ParseError;
+from_uint!(
+    from_u8 u8,
+    from_u16 u16,
+    from_u32 u32,
+    from_u64 u64,
+    from_u128 u128,
+    from_usize usize,
+);
 
-    #[inline]
-    fn try_from(n: f64) -> Result<Self, Self::Error> {
-        if n.is_sign_negative() {
-            return Err(ParseError::Signed);
-        }
-        Ok(Self::new(Decimal::from(n)))
-    }
-}
+try_from_num!(
+    from_i8 i8,
+    from_i16 i16,
+    from_i32 i32,
+    from_i64 i64,
+    from_i128 i128,
+    from_isize isize,
+
+    from_f32 f32,
+    from_f64 f64,
+);
+

--- a/src/decimal/udec/impls/to.rs
+++ b/src/decimal/udec/impls/to.rs
@@ -1,6 +1,6 @@
 use core::num::IntErrorKind;
 
-use crate::decimal::UnsignedDecimal;
+use crate::decimal::{UnsignedDecimal, Decimal};
 
 type UD<const N: usize> = UnsignedDecimal<N>;
 
@@ -68,5 +68,10 @@ impl<const N: usize> UD<N> {
     /// Converts [UnsignedDecimal] into [`f64`].
     pub const fn to_f64(self) -> f64 {
         self.0.to_f64()
+    }
+
+    /// Converts [UnsignedDecimal] into [Decimal].
+    pub const fn to_decimal(self) -> Decimal<N> {
+        Decimal::from_unsigned_decimal(self)
     }
 }

--- a/src/decimal/udec/impls/to.rs
+++ b/src/decimal/udec/impls/to.rs
@@ -1,17 +1,72 @@
+use core::num::IntErrorKind;
+
 use crate::decimal::UnsignedDecimal;
 
 type UD<const N: usize> = UnsignedDecimal<N>;
 
-impl<const N: usize> From<UD<N>> for f32 {
-    #[inline]
-    fn from(d: UD<N>) -> Self {
-        f32::from(d.0)
+macro_rules! to_num_impls {
+    ($($name:ident $num:ty,)*) => {
+        $(
+            impl<const N: usize> TryFrom<UD<N>> for $num {
+                type Error = IntErrorKind;
+
+                #[inline]
+                fn try_from(ud: UD<N>) -> Result<Self, Self::Error> {
+                    <$num>::try_from(ud.0)
+                }
+            }
+        )*
+
+        impl<const N: usize> UD<N> {
+            $(
+                #[inline]
+                #[doc = concat!("Converts [UnsignedDecimal] into [`", stringify!($num), "`].")]
+                pub const fn $name(self) -> Result<$num, IntErrorKind> {
+                    self.0.$name()
+                }
+            )*
+        }
     }
 }
 
+to_num_impls!(
+    to_u8 u8,
+    to_u16 u16,
+    to_u32 u32,
+    to_u64 u64,
+    to_u128 u128,
+    to_usize usize,
+
+    to_i8 i8,
+    to_i16 i16,
+    to_i32 i32,
+    to_i64 i64,
+    to_i128 i128,
+    to_isize isize,
+);
+
+
+impl<const N: usize> From<UD<N>> for f32 {
+    #[inline]
+    fn from(d: UD<N>) -> f32 {
+        f32::from(d.0)
+    }
+}
 impl<const N: usize> From<UD<N>> for f64 {
     #[inline]
-    fn from(d: UD<N>) -> Self {
+    fn from(d: UD<N>) -> f64 {
         f64::from(d.0)
+    }
+}
+
+impl<const N: usize> UD<N> {
+    /// Converts [UnsignedDecimal] into [`f32`].
+    pub const fn to_f32(self) -> f32 {
+        self.0.to_f32()
+    }
+
+    /// Converts [UnsignedDecimal] into [`f64`].
+    pub const fn to_f64(self) -> f64 {
+        self.0.to_f64()
     }
 }


### PR DESCRIPTION
this fixes https://github.com/neogenie/fastnum/issues/13 .

I does not add unit tests for these constant functions: due to it's do same thing as From traits, if has some unit tests about From traits, it should also covers this case.