### PR TITLE
Add const fn to_rust_decimal() for Decimal<N>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bytes = { version = "1.1.0", default-features = false, optional = true }
 byteorder = { version = "1.5.0", default-features = false, optional = true }
 utoipa = { version = ">= 5.0.0", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.13", default-features = false, optional = true }
+rust_decimal = { version = "^1", default-features = false, features = ["macros"], optional = true }
 
 [dev-dependencies]
 rstest = { version = "0.23.0" }
@@ -53,7 +54,7 @@ autocfg = "1"
 default = ["std"]
 std = []
 
-numtraits = ["num-traits", "bnum/numtraits"]
+numtraits = ["dep:num-traits", "bnum/numtraits"]
 
 rand = ["dep:rand"]
 zeroize = ["dep:zeroize"]
@@ -72,11 +73,13 @@ utoipa = ["dep:utoipa", "utoipa/macros"]
 
 tokio-postgres = ["dep:tokio-postgres", "extra-postgres-encode"]
 
+rust_decimal = ["dep:rust_decimal", "dep:num-traits"]
+
 dev = []
 
 # For internal use only
-test-util = ["num-traits"]
-extra-postgres = ["num-traits"]
+test-util = ["dep:num-traits"]
+extra-postgres = ["dep:num-traits"]
 extra-postgres-encode = ["extra-postgres", "bytes", "byteorder"]
 
 [profile.release]

--- a/src/decimal/dec/extras.rs
+++ b/src/decimal/dec/extras.rs
@@ -10,5 +10,8 @@ mod serde;
 #[cfg(feature = "utoipa")]
 mod utoipa;
 
+#[cfg(feature = "rust_decimal")]
+mod rust_decimal;
+
 #[cfg(feature = "tokio-postgres")]
 mod tokio_postgres;

--- a/src/decimal/dec/extras/rust_decimal.rs
+++ b/src/decimal/dec/extras/rust_decimal.rs
@@ -1,0 +1,161 @@
+use crate::decimal::{Decimal, UnsignedDecimal};
+
+const MAX_RUST_DECIMAL_MANTISSA: u128 = (1u128 << 96) - 1;
+
+/// Core conversion logic that extracts the mantissa and scale from fastnum internal representation
+/// and converts it to rust_decimal format.
+const fn convert_to_rust_decimal_core<const N: usize>(
+    fast_digits_bnum: &crate::int::UInt<N>,
+    fn_scale: i16,
+    is_negative: bool,
+    is_finite: bool,
+) -> rust_decimal::Decimal {
+    if !is_finite {
+        panic!("Cannot convert non-finite value (NaN or Infinity) to rust_decimal::Decimal at compile time");
+    }
+
+    let limbs = fast_digits_bnum.digits();
+
+    let initial_mantissa_u128: u128 = if N == 0 {
+        0
+    } else if N == 1 {
+        limbs[0] as u128
+    } else if N == 2 {
+        (limbs[1] as u128) << 64 | (limbs[0] as u128)
+    } else {
+        let mut i = 2;
+        while i < N {
+            if limbs[i] != 0 {
+                panic!("Mantissa too large for rust_decimal::Decimal");
+            }
+            i += 1;
+        }
+        // If all higher limbs are zero, construct from the first two limbs
+        (limbs[1] as u128) << 64 | (limbs[0] as u128)
+    };
+
+    let mut working_fn_scale = fn_scale;
+    let mut working_mantissa_u128 = initial_mantissa_u128;
+
+    // rust_decimal::Decimal stores m / 10^e where e is 0-28.
+    // fastnum::Decimal stores digits * 10^-scale.
+    // If fastnum scale is negative, e.g., -2 for 12300 (digits=123, scale=-2),
+    // it means the number is digits * 10^abs(scale).
+    // So, rust_decimal mantissa should be fastnum_digits * 10^abs(fn_scale)
+    // and rust_decimal scale should be 0.
+    if working_fn_scale < 0 {
+        let positive_scale_factor = -working_fn_scale as u32;
+        if positive_scale_factor > 0 {
+            let mut multiplier: u128 = 1;
+            let mut current_power: u32 = 0;
+            while current_power < positive_scale_factor {
+                if multiplier > u128::MAX / 10 {
+                    panic!("Mantissa overflow when adjusting for negative scale (multiplier too large)");
+                }
+                multiplier *= 10;
+                current_power += 1;
+            }
+            if initial_mantissa_u128 > u128::MAX / multiplier {
+                panic!("Mantissa overflow when adjusting for negative scale (multiplication)");
+            }
+            working_mantissa_u128 = initial_mantissa_u128 * multiplier;
+        }
+        working_fn_scale = 0;
+    }
+
+    let rd_scale = working_fn_scale as u32;
+
+    if rd_scale > rust_decimal::Decimal::MAX_SCALE {
+        panic!("Scale out of bounds for rust_decimal::Decimal");
+    }
+
+    if working_mantissa_u128 > MAX_RUST_DECIMAL_MANTISSA {
+        panic!("Mantissa too large for rust_decimal::Decimal");
+    }
+
+    let lo = (working_mantissa_u128 & 0xFFFFFFFF) as u32;
+    let mid = ((working_mantissa_u128 >> 32) & 0xFFFFFFFF) as u32;
+    let hi = ((working_mantissa_u128 >> 64) & 0xFFFFFFFF) as u32;
+
+    rust_decimal::Decimal::from_parts(lo, mid, hi, is_negative, rd_scale)
+}
+
+impl<const N: usize> Decimal<N> {
+    /// Converts this `fastnum::Decimal` to a `rust_decimal::Decimal` at compile time.
+    ///
+    /// This function will panic during compilation if the conversion is not possible,
+    /// for example, if the value is too large to be represented by `rust_decimal::Decimal`
+    /// or the scale is out of bounds.
+    ///
+    /// Requires the `rust_decimal` feature to be enabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics at compile-time if:
+    /// - The `Decimal` is NaN or Infinity.
+    /// - The number of digits in the coefficient (after adjusting for negative scale) exceeds
+    ///   the capacity of `rust_decimal::Decimal` (approximately 28-29 digits or 96 bits).
+    /// - The scale is outside the range supported by `rust_decimal::Decimal` (0-28).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fastnum::{dec128, D128};
+    ///
+    /// const FASTNUM_VAL: D128 = dec128!(0.27);
+    /// const RUST_DEC_VAL: rust_decimal::Decimal = FASTNUM_VAL.to_rust_decimal();
+    /// assert_eq!(RUST_DEC_VAL, rust_decimal::Decimal::new(27, 2));
+    ///
+    /// const FASTNUM_NEG_SCALE: D128 = dec128!(12300);
+    /// const RUST_DEC_NEG_SCALE: rust_decimal::Decimal = FASTNUM_NEG_SCALE.to_rust_decimal();
+    /// assert_eq!(RUST_DEC_NEG_SCALE, rust_decimal::Decimal::new(12300, 0));
+    /// ```
+    pub const fn to_rust_decimal(&self) -> rust_decimal::Decimal {
+        let fast_digits_bnum = self.digits();
+        let fn_scale = self.fractional_digits_count();
+        let is_negative = self.is_negative();
+        let is_finite = self.is_finite();
+
+        convert_to_rust_decimal_core(&fast_digits_bnum, fn_scale, is_negative, is_finite)
+    }
+}
+
+impl<const N: usize> UnsignedDecimal<N> {
+    /// Converts this `fastnum::UnsignedDecimal` to a `rust_decimal::Decimal` at compile time.
+    ///
+    /// This function will panic during compilation if the conversion is not possible,
+    /// for example, if the value is too large to be represented by `rust_decimal::Decimal`
+    /// or the scale is out of bounds.
+    ///
+    /// Requires the `rust_decimal` feature to be enabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics at compile-time if:
+    /// - The `UnsignedDecimal` is NaN or Infinity.
+    /// - The number of digits in the coefficient (after adjusting for negative scale) exceeds
+    ///   the capacity of `rust_decimal::Decimal` (approximately 28-29 digits or 96 bits).
+    /// - The scale is outside the range supported by `rust_decimal::Decimal` (0-28).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fastnum::{udec128, UD128};
+    ///
+    /// const FASTNUM_VAL: UD128 = udec128!(0.27);
+    /// const RUST_DEC_VAL: rust_decimal::Decimal = FASTNUM_VAL.to_rust_decimal();
+    /// assert_eq!(RUST_DEC_VAL, rust_decimal::Decimal::new(27, 2));
+    ///
+    /// const FASTNUM_NEG_SCALE: UD128 = udec128!(12300);
+    /// const RUST_DEC_NEG_SCALE: rust_decimal::Decimal = FASTNUM_NEG_SCALE.to_rust_decimal();
+    /// assert_eq!(RUST_DEC_NEG_SCALE, rust_decimal::Decimal::new(12300, 0));
+    /// ```
+    pub const fn to_rust_decimal(&self) -> rust_decimal::Decimal {
+        let fast_digits_bnum = self.digits();
+        let fn_scale = self.fractional_digits_count();
+        let is_negative = false;
+        let is_finite = self.is_finite();
+
+        convert_to_rust_decimal_core(&fast_digits_bnum, fn_scale, is_negative, is_finite)
+    }
+}

--- a/tests/decimal/common/to.rs
+++ b/tests/decimal/common/to.rs
@@ -1,5 +1,6 @@
 pub(crate) mod f32;
 pub(crate) mod f64;
 pub(crate) mod float;
+pub(crate) mod rust_decimal;
 // pub(crate) mod int;
 // pub(crate) mod uint;

--- a/tests/decimal/common/to/rust_decimal.rs
+++ b/tests/decimal/common/to/rust_decimal.rs
@@ -1,0 +1,165 @@
+macro_rules! test_impl {
+    (D, $bits: literal) => {
+        paste::paste! { test_impl!(SIGNED: $bits, [< dec $bits >], [<D $bits>]); test_impl!(UNSIGNED: $bits, [< udec $bits >], [<D $bits>]); }
+    };
+    (UD, $bits: literal) => {
+        paste::paste! { test_impl!(UNSIGNED: $bits, [< udec $bits >], [<UD $bits>]); }
+    };
+
+    (SIGNED: $bits: tt, $dec: ident, $D: ident) => {
+        mod $dec {
+            use fastnum::decimal::Context;
+            use fastnum::*;
+            use rstest::*;
+            use rust_decimal::dec;
+
+            #[rstest(::trace)]
+            #[case(-42)]
+            #[case(-123456789)]
+            fn test_basic_conversions(#[case] val: i32) {
+                let fastnum_val = $D::from(val);
+                let rust_dec_val = fastnum_val.to_rust_decimal();
+                let expected = rust_decimal::Decimal::from(val);
+                assert_eq!(rust_dec_val, expected);
+            }
+
+            #[rstest(::trace)]
+            #[case("-123.456")]
+            #[case("-79228162514264337593543950335")] // Max negative mantissa
+            fn test_string_conversions(#[case] val_str: &str) {
+                let fastnum_val = $D::parse_str(val_str, Context::default());
+                let rust_dec_val = fastnum_val.to_rust_decimal();
+                let expected = rust_decimal::Decimal::from_str_exact(val_str).unwrap();
+                assert_eq!(rust_dec_val, expected);
+            }
+
+            #[test]
+            fn test_negative_scale() {
+                // Scale represents the power of 10 divisor
+                // digits 123, scale -2 represents 123 / 10^2 = 1.23
+                let fastnum_val = $D::from_parts(
+                    123u32.into(),
+                    -2,
+                    fastnum::decimal::Sign::Plus,
+                    Context::default(),
+                );
+                let rust_dec_val = fastnum_val.to_rust_decimal();
+                let expected = dec!(1.23);
+                assert_eq!(rust_dec_val, expected);
+            }
+
+            #[test]
+            #[should_panic(expected = "Scale out of bounds for rust_decimal::Decimal")]
+            fn test_scale_too_high_should_panic() {
+                // 29 decimal places should panic
+                let val_str = "-0.12345678901234567890123456789"; // 29 decimal places
+                let fastnum_val = $D::parse_str(val_str, Context::default());
+                fastnum_val.to_rust_decimal();
+            }
+
+            #[test]
+            #[should_panic(expected = "Mantissa too large for rust_decimal::Decimal")]
+            fn test_mantissa_too_large_should_panic() {
+                // 2^96 (one larger than max for rust_decimal)
+                let val_str = "-79228162514264337593543950336";
+                let fastnum_val = $D::parse_str(val_str, Context::default());
+                fastnum_val.to_rust_decimal();
+            }
+
+            #[test]
+            #[should_panic(expected = "Cannot convert non-finite value (NaN or Infinity) to rust_decimal::Decimal at compile time")]
+            fn test_negative_infinity_should_panic() {
+                $D::NEG_INFINITY.to_rust_decimal();
+            }
+        }
+    };
+
+    (UNSIGNED: $bits: tt, $udec: ident, $UD: ident) => {
+        mod $udec {
+            use fastnum::decimal::Context;
+            use fastnum::*;
+            use rstest::*;
+            use rust_decimal::dec;
+
+            #[rstest(::trace)]
+            #[case(0)]
+            #[case(42)]
+            #[case(123456789)]
+            fn test_basic_conversions(#[case] val: u32) {
+                let fastnum_val = $UD::from(val);
+                let rust_dec_val = fastnum_val.to_rust_decimal();
+                let expected = rust_decimal::Decimal::from(val);
+                assert_eq!(rust_dec_val, expected);
+            }
+
+            #[rstest(::trace)]
+            #[case("123.456")]
+            #[case("0.1234567890123456789012345678")] // 28 decimal places (max for rust_decimal)
+            #[case("79228162514264337593543950335")] // Max mantissa for rust_decimal
+            fn test_string_conversions(#[case] val_str: &str) {
+                let fastnum_val = $UD::parse_str(val_str, Context::default());
+                let rust_dec_val = fastnum_val.to_rust_decimal();
+                let expected = rust_decimal::Decimal::from_str_exact(val_str).unwrap();
+                assert_eq!(rust_dec_val, expected);
+            }
+
+            #[test]
+            fn test_negative_scale() {
+                // Scale represents the power of 10 divisor
+                // digits 123, scale -2 represents 123 / 10^2 = 1.23
+                let fastnum_val = $UD::from_parts(
+                    123u32.into(),
+                    -2,
+                    Context::default(),
+                );
+                let rust_dec_val = fastnum_val.to_rust_decimal();
+                let expected = dec!(1.23);
+                assert_eq!(rust_dec_val, expected);
+            }
+
+            #[test]
+            fn test_zero_scale() {
+                let fastnum_val = $UD::from_parts(
+                    12300u32.into(),
+                    0,
+                    Context::default(),
+                );
+                let rust_dec_val = fastnum_val.to_rust_decimal();
+                let expected = dec!(12300);
+                assert_eq!(rust_dec_val, expected);
+            }
+
+            #[test]
+            #[should_panic(expected = "Scale out of bounds for rust_decimal::Decimal")]
+            fn test_scale_too_high_should_panic() {
+                // 29 decimal places should panic
+                let val_str = "0.12345678901234567890123456789"; // 29 decimal places
+                let fastnum_val = $UD::parse_str(val_str, Context::default());
+                fastnum_val.to_rust_decimal();
+            }
+
+            #[test]
+            #[should_panic(expected = "Mantissa too large for rust_decimal::Decimal")]
+            fn test_mantissa_too_large_should_panic() {
+                // 2^96 (one larger than max for rust_decimal)
+                let val_str = "79228162514264337593543950336";
+                let fastnum_val = $UD::parse_str(val_str, Context::default());
+                fastnum_val.to_rust_decimal();
+            }
+
+            #[test]
+            #[should_panic(expected = "Cannot convert non-finite value (NaN or Infinity) to rust_decimal::Decimal at compile time")]
+            fn test_nan_should_panic() {
+                $UD::NAN.to_rust_decimal();
+            }
+
+            #[test]
+            #[should_panic(expected = "Cannot convert non-finite value (NaN or Infinity) to rust_decimal::Decimal at compile time")]
+            fn test_infinity_should_panic() {
+                $UD::INFINITY.to_rust_decimal();
+            }
+        }
+    };
+}
+
+pub(crate) use test_impl;

--- a/tests/decimal/extras.rs
+++ b/tests/decimal/extras.rs
@@ -4,6 +4,9 @@ pub(crate) mod utoipa;
 #[cfg(feature = "serde")]
 pub(crate) mod serde;
 
+#[cfg(feature = "rust_decimal")]
+pub(crate) mod rust_decimal;
+
 #[cfg(feature = "diesel")]
 pub(crate) mod diesel;
 

--- a/tests/decimal/extras/rust_decimal.rs
+++ b/tests/decimal/extras/rust_decimal.rs
@@ -1,0 +1,15 @@
+use crate::decimal::common::to::rust_decimal::test_impl;
+
+test_impl!(D, 64);
+test_impl!(UD, 64);
+test_impl!(D, 128);
+test_impl!(UD, 128);
+test_impl!(D, 256);
+test_impl!(UD, 256);
+test_impl!(D, 512);
+test_impl!(UD, 512);
+test_impl!(D, 1024);
+test_impl!(UD, 1024);
+test_impl!(D, 2048);
+test_impl!(UD, 2048);
+// 4096 and 8192 bit widths are causing compilation timeout issues with long constant evaluation


### PR DESCRIPTION
This commit introduces a `const fn to_rust_decimal(&self) -> rust_decimal::Decimal` method for the `fastnum::Decimal<N>` type. This allows for compile-time conversion from fastnum's decimal types to `rust_decimal::Decimal`.

The functionality is enabled by a new "rust_decimal" feature flag.

The method handles:
- Conversion of mantissa and scale from fastnum's representation (including negative scales where the mantissa is adjusted by powers of 10).
- Validation of mantissa against `rust_decimal::Decimal`'s 96-bit limit.
- Validation of scale against `rust_decimal::Decimal`'s 0-28 limit.
- Panics at compile time for NaN, Infinity, or out-of-range values.
- Correctly sources mantissa components for D64, D128, and larger types (D256+), panicking if a D256+ mantissa exceeds u128::MAX before further processing.

Uses `rust_decimal::Decimal::from_parts` internally to ensure const compatibility.

fixes #33 