### PR TITLE
Add truncate operation

### DIFF
--- a/doc/LIB.md
+++ b/doc/LIB.md
@@ -1481,6 +1481,38 @@ assert!(D256::NEG_INFINITY.with_ctx(ctx).rescale(2).is_nan());
 assert!(D256::NAN.with_ctx(ctx).rescale(1).is_nan());                                    
 ```
 
+## Truncate
+
+[truncate]: #truncate
+
+[`truncate(self, precision)`](crate::decimal::Decimal::truncate)
+
+If `self` is a [special value] then the [general rules] apply, and an [`Invalid operation`] condition is raised
+and the result is [`NaN`].
+Otherwise, `truncate` quantize the `self` decimal number specified to the power of ten of the quantum (`precision`).
+
+The coefficient:
+
+- **Is not rounded**, in opposition to rescale
+
+### Examples
+
+```                                                                                       
+use fastnum::{*, decimal::*};
+
+assert_eq!(dec256!(2.17).truncate(3), dec256!(2.170));
+assert_eq!(dec256!(2.17).truncate(2), dec256!(2.17));
+assert_eq!(dec256!(2.17).truncate(1), dec256!(2.1));
+assert_eq!(dec256!(2.9).truncate(0), dec256!(2));
+assert_eq!(dec256!(2.17).truncate(-1), dec256!(0));
+
+
+assert!(D256::INFINITY.with_ctx(ctx).truncate(2).is_nan());
+assert!(D256::NEG_INFINITY.with_ctx(ctx).truncate(2).is_nan());
+assert!(D256::NAN.with_ctx(ctx).truncate(1).is_nan());                                 
+```
+
+
 ## Quantize
 
 [quantize]: #quantize

--- a/doc/LIB.md
+++ b/doc/LIB.md
@@ -1497,19 +1497,30 @@ The coefficient:
 
 ### Examples
 
-```                                                                                       
+```
 use fastnum::{*, decimal::*};
 
-assert_eq!(dec256!(2.17).truncate(3), dec256!(2.170));
-assert_eq!(dec256!(2.17).truncate(2), dec256!(2.17));
-assert_eq!(dec256!(2.17).truncate(1), dec256!(2.1));
-assert_eq!(dec256!(2.9).truncate(0), dec256!(2));
-assert_eq!(dec256!(2.17).truncate(-1), dec256!(0));
+let ctx = Context::default().without_traps();                                                        
 
+fn assert_eq_value(a: fastnum::D256, b: fastnum::D256) {
+  assert_eq!(a.digits(), b.digits(), "{} != {}", a, b);
+  assert_eq!(
+      a.fractional_digits_count(),
+      b.fractional_digits_count(),
+      "{} != {}",
+      a,
+      b
+  );
+}
 
-assert!(D256::INFINITY.with_ctx(ctx).truncate(2).is_nan());
-assert!(D256::NEG_INFINITY.with_ctx(ctx).truncate(2).is_nan());
-assert!(D256::NAN.with_ctx(ctx).truncate(1).is_nan());                                 
+assert_eq_value(dec256!(2.17).truncate(3),dec256!(2.170));
+assert_eq_value(dec256!(2.17).truncate(2), dec256!(2.17));
+assert_eq_value(dec256!(2.17).truncate(1), dec256!(2.1));
+assert_eq_value(dec256!(2.9).truncate(0), dec256!(2));
+assert_eq_value(dec256!(2.17).truncate(-1), dec256!(0).rescale(-1));
+
+assert!(D256::NEG_INFINITY.with_ctx(ctx).rescale(2).is_nan());
+assert!(D256::NAN.with_ctx(ctx).rescale(1).is_nan());
 ```
 
 

--- a/src/decimal/dec.rs
+++ b/src/decimal/dec.rs
@@ -1663,6 +1663,40 @@ impl<const N: usize> Decimal<N> {
         self.round_extra_precision().check()
     }
 
+    /// Returns the given decimal number _truncated_ to `digits` precision after
+    /// the decimal point, with no rounding.
+    #[doc = doc::decimal_operation_panics!("truncate operation")]
+    /// # Examples
+    ///
+    /// ```
+    /// use fastnum::{*, decimal::*};
+    ///
+    /// assert_eq!(dec256!(2.17).truncate(3), dec256!(2.170));
+    /// assert_eq!(dec256!(2.17).truncate(2), dec256!(2.17));
+    /// assert_eq!(dec256!(2.17).truncate(1), dec256!(2.1));
+    /// assert_eq!(dec256!(2.9).truncate(0), dec256!(2));
+    /// assert_eq!(dec256!(2.17).truncate(-1), dec256!(0));
+    ///
+    /// let ctx = Context::default().without_traps();
+    ///
+    /// assert!(D256::INFINITY.with_ctx(ctx).truncate(2).is_nan());
+    /// assert!(D256::NEG_INFINITY.with_ctx(ctx).truncate(2).is_nan());
+    /// assert!(D256::NAN.with_ctx(ctx).truncate(1).is_nan());
+    /// ```
+    ///
+    /// See also:
+    /// - More about [`truncate`](crate#truncate) decimals.
+    /// - [Self::quantize].
+    #[must_use = doc::must_use_op!()]
+    #[track_caller]
+    #[inline]
+    pub const fn truncate(self, precision: i16) -> Self {
+        self.with_rounding_mode(RoundingMode::No)
+            .round(precision)
+            // We need to reset the rounding mode to the default, for future operations
+            .with_rounding_mode(RoundingMode::default())
+    }
+
     /// Returns a value equal to `self` (rounded), having the exponent of
     /// `other`.
     #[doc = doc::decimal_operation_panics!("quantize operation")]

--- a/src/decimal/dec.rs
+++ b/src/decimal/dec.rs
@@ -1671,11 +1671,22 @@ impl<const N: usize> Decimal<N> {
     /// ```
     /// use fastnum::{*, decimal::*};
     ///
-    /// assert_eq!(dec256!(2.17).truncate(3), dec256!(2.170));
-    /// assert_eq!(dec256!(2.17).truncate(2), dec256!(2.17));
-    /// assert_eq!(dec256!(2.17).truncate(1), dec256!(2.1));
-    /// assert_eq!(dec256!(2.9).truncate(0), dec256!(2));
-    /// assert_eq!(dec256!(2.17).truncate(-1), dec256!(0));
+    /// fn assert_eq_value(a: fastnum::D256, b: fastnum::D256) {
+    ///   assert_eq!(a.digits(), b.digits(), "{} != {}", a, b);
+    ///   assert_eq!(
+    ///       a.fractional_digits_count(),
+    ///       b.fractional_digits_count(),
+    ///       "{} != {}",
+    ///       a,
+    ///       b
+    ///   );
+    /// }
+    ///
+    /// assert_eq_value(dec256!(2.17).truncate(3),dec256!(2.170));
+    /// assert_eq_value(dec256!(2.17).truncate(2), dec256!(2.17));
+    /// assert_eq_value(dec256!(2.17).truncate(1), dec256!(2.1));
+    /// assert_eq_value(dec256!(2.9).truncate(0), dec256!(2));
+    /// assert_eq_value(dec256!(2.17).truncate(-1), dec256!(0).rescale(-1));
     ///
     /// let ctx = Context::default().without_traps();
     ///
@@ -1690,11 +1701,9 @@ impl<const N: usize> Decimal<N> {
     #[must_use = doc::must_use_op!()]
     #[track_caller]
     #[inline]
-    pub const fn truncate(self, precision: i16) -> Self {
-        self.with_rounding_mode(RoundingMode::No)
-            .round(precision)
-            // We need to reset the rounding mode to the default, for future operations
-            .with_rounding_mode(RoundingMode::default())
+    pub const fn truncate(mut self, precision: i16) -> Self {
+        scale::rescale(&mut self, precision);
+        self.check()
     }
 
     /// Returns a value equal to `self` (rounded), having the exponent of

--- a/src/decimal/udec.rs
+++ b/src/decimal/udec.rs
@@ -1172,11 +1172,22 @@ impl<const N: usize> UnsignedDecimal<N> {
     /// ```
     /// use fastnum::{*, decimal::*};
     ///
-    /// assert_eq!(udec256!(2.17).truncate(3), udec256!(2.170));
-    /// assert_eq!(udec256!(2.17).truncate(2), udec256!(2.17));
-    /// assert_eq!(udec256!(2.17).truncate(1), udec256!(2.1));
-    /// assert_eq!(udec256!(2.9).truncate(0), udec256!(2));
-    /// assert_eq!(udec256!(2.17).truncate(-1), udec256!(0));
+    /// fn assert_eq_value(a: fastnum::D256, b: fastnum::D256) {
+    ///   assert_eq!(a.digits(), b.digits(), "{} != {}", a, b);
+    ///   assert_eq!(
+    ///       a.fractional_digits_count(),
+    ///       b.fractional_digits_count(),
+    ///       "{} != {}",
+    ///       a,
+    ///       b
+    ///   );
+    /// }
+    ///
+    /// assert_eq_value(dec256!(2.17).truncate(3),dec256!(2.170));
+    /// assert_eq_value(dec256!(2.17).truncate(2), dec256!(2.17));
+    /// assert_eq_value(dec256!(2.17).truncate(1), dec256!(2.1));
+    /// assert_eq_value(dec256!(2.9).truncate(0), dec256!(2));
+    /// assert_eq_value(dec256!(2.17).truncate(-1), dec256!(0).rescale(-1));
     ///
     /// let ctx = Context::default().without_traps();
     ///

--- a/src/decimal/udec.rs
+++ b/src/decimal/udec.rs
@@ -1164,6 +1164,37 @@ impl<const N: usize> UnsignedDecimal<N> {
         self
     }
 
+    /// Returns the given decimal number _truncated_ to `digits` precision after
+    /// the decimal point.
+    #[doc = doc::decimal_operation_panics!("truncate operation")]
+    /// # Examples
+    ///
+    /// ```
+    /// use fastnum::{*, decimal::*};
+    ///
+    /// assert_eq!(udec256!(2.17).truncate(3), udec256!(2.170));
+    /// assert_eq!(udec256!(2.17).truncate(2), udec256!(2.17));
+    /// assert_eq!(udec256!(2.17).truncate(1), udec256!(2.1));
+    /// assert_eq!(udec256!(2.9).truncate(0), udec256!(2));
+    /// assert_eq!(udec256!(2.17).truncate(-1), udec256!(0));
+    ///
+    /// let ctx = Context::default().without_traps();
+    ///
+    /// assert!(UD256::INFINITY.with_ctx(ctx).truncate(2).is_nan());
+    /// assert!(UD256::NAN.with_ctx(ctx).truncate(1).is_nan());
+    /// ```
+    ///
+    /// See also:
+    /// - More about [`truncate`](crate#truncate) decimals.
+    /// - [Self::quantize].
+    #[must_use = doc::must_use_op!()]
+    #[track_caller]
+    #[inline]
+    pub const fn truncate(mut self, precision: i16) -> Self {
+        self.0 = self.0.truncate(precision);
+        self
+    }
+
     /// Returns a value equal to `self` (rounded), having the exponent of
     /// `other`.
     #[doc = doc::decimal_operation_panics!("quantize operation")]


### PR DESCRIPTION
Add a way to scale the number without a rounding operation.

Fixes #39 