### PR TITLE
Make mermaid diagram in docs readable in dark mode

### DIFF
--- a/doc/LIB.md
+++ b/doc/LIB.md
@@ -322,6 +322,7 @@ _control block_ which consists of the following components:
 .mermaid svg { 
   max-width: 100% !important; 
   height: auto;
+  background-color: rgba(255,255,255,50%);
 }
 </style>
 <pre class="mermaid">


### PR DESCRIPTION
Add a slight background to the mermaid diagrams in `docs/LIB.md` so that they are readable in dark mode.

Before:
<img width="2365" height="873" alt="image" src="https://github.com/user-attachments/assets/924a4c76-493f-448e-a24f-10068167a777" />

After:
<img width="2372" height="871" alt="image" src="https://github.com/user-attachments/assets/aa56ae47-c2ac-4c85-add4-40632e6f0fb6" />

Light mode is barely affected:
<img width="2369" height="855" alt="image" src="https://github.com/user-attachments/assets/b914b7ea-a00b-4d4e-a41e-dfe2e856985e" />
