### PR TITLE
Add a feature to use Display as Decimal's Debug output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ test-util = ["num-traits/std"]
 extra-postgres = ["num-traits"]
 extra-postgres-encode = ["extra-postgres", "bytes", "byteorder"]
 
+debug_display = []
+
 [profile.release]
 lto = true # enable link-time optimization for faster runtime, but slower compile time
 opt-level = 3 # maximum optimization level for faster runtime, but slower compile time

--- a/examples/debug_display/Cargo.toml
+++ b/examples/debug_display/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "debug_display"
+version = "0.0.1"
+authors = ["Neo"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+fastnum = { path = "../../", features = ["debug_display"] }

--- a/examples/debug_display/src/main.rs
+++ b/examples/debug_display/src/main.rs
@@ -1,0 +1,6 @@
+use fastnum::*;
+
+fn main() {
+    assert_eq!(format!("{:?}", D128::from(1)), "1".to_string());
+    assert_eq!(format!("{:?}", D128::parse_str("0.002", decimal::Context::default())), "0.002".to_string());
+}

--- a/src/decimal/dec/impls/fmt.rs
+++ b/src/decimal/dec/impls/fmt.rs
@@ -1,6 +1,6 @@
 use core::fmt::{self, Debug, Display, Formatter, LowerExp, UpperExp};
 
-use crate::decimal::{dec::format, utils, Decimal};
+use crate::decimal::{dec::format, Decimal};
 
 impl<const N: usize> Display for Decimal<N> {
     #[inline]
@@ -50,7 +50,7 @@ impl<const N: usize> Debug for Decimal<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         #[cfg(not(feature = "debug_display"))]
         {
-            utils::fmt::debug_print(&self.digits, &self.cb, Self::type_name(), f)
+            crate::decimal::utils::fmt::debug_print(&self.digits, &self.cb, Self::type_name(), f)
         }
 
         #[cfg(feature = "debug_display")]

--- a/src/decimal/dec/impls/fmt.rs
+++ b/src/decimal/dec/impls/fmt.rs
@@ -48,6 +48,14 @@ impl<const N: usize> UpperExp for Decimal<N> {
 
 impl<const N: usize> Debug for Decimal<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        utils::fmt::debug_print(&self.digits, &self.cb, Self::type_name(), f)
+        #[cfg(not(feature = "debug_display"))]
+        {
+            utils::fmt::debug_print(&self.digits, &self.cb, Self::type_name(), f)
+        }
+
+        #[cfg(feature = "debug_display")]
+        {
+            write!(f, "{}", self)
+        }
     }
 }


### PR DESCRIPTION
As a user, the default Debug impl is hard to reason, so I add a feature to let client switch to human friendlier debug output. 