### PR TITLE
fix: const generic inference for Rust 1.87 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,120 @@
+name: Rust CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  MSRV: '1.87'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+      - name: Install Rust toolchain via rustup
+        run: |
+          rustup component add clippy
+          rustup component add rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Check linting
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-docs-
+            ${{ runner.os }}-cargo-
+      - name: Install Rust nightly
+        run: rustup install nightly --profile minimal
+      - name: Build docs
+        run: cargo +nightly doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+
+  test:
+    name: Test (${{ matrix.rust-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        rust-version: [ '1.87', 'stable' ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ matrix.rust-version }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.rust-version }}-
+            ${{ runner.os }}-cargo-
+      - name: Install Rust ${{ matrix.rust-version }}
+        run: |
+          if [ "${{ matrix.rust-version }}" != "stable" ]; then
+            rustup install ${{ matrix.rust-version }} --profile minimal
+          fi
+      - name: Build (no features)
+        run: cargo +${{ matrix.rust-version }} build --no-default-features
+      - name: Build (default features)
+        run: cargo +${{ matrix.rust-version }} build
+      - name: Build (std feature)
+        run: cargo +${{ matrix.rust-version }} build --features std
+      - name: Build (numtraits feature)
+        run: cargo +${{ matrix.rust-version }} build --features numtraits
+      - name: Build (all features)
+        run: cargo +${{ matrix.rust-version }} build --all-features
+      - name: Test (no features)
+        run: cargo +${{ matrix.rust-version }} test --no-default-features
+      - name: Test (default features)
+        run: cargo +${{ matrix.rust-version }} test
+      - name: Test (std feature)
+        run: cargo +${{ matrix.rust-version }} test --features std
+      - name: Test (numtraits feature)
+        run: cargo +${{ matrix.rust-version }} test --features numtraits
+      - name: Test (test-util feature for integration tests)
+        run: cargo +${{ matrix.rust-version }} test --features test-util
+      - name: Test docs (all features)
+        run: cargo +${{ matrix.rust-version }} test --doc --all-features
+
+  check-msrv:
+    name: Verify MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Verify MSRV
+        run: cargo msrv verify

--- a/src/bint/int/intrinsics/transmute.rs
+++ b/src/bint/int/intrinsics/transmute.rs
@@ -17,13 +17,13 @@ pub const unsafe fn transmute<const N: usize, const M: usize>(v: Int<N>) -> Int<
             digits
         } else {
             // For positive values, initialize with zeros (existing behavior)
-            _transmute::<_, _, N>(src_digits)
+            _transmute::<N, M, N>(src_digits)
         }
     } else {
         // Narrowing conversion
         debug_assert!(v.last_digit_index() < M);
         debug_assert!(v.bits() <= Int::<M>::BITS);
-        _transmute::<_, _, M>(src_digits)
+        _transmute::<N, M, M>(src_digits)
     };
 
     Int::from_digits(digits)

--- a/src/bint/uint/intrinsics/transmute.rs
+++ b/src/bint/uint/intrinsics/transmute.rs
@@ -4,10 +4,10 @@ use crate::bint::{intrinsics::_transmute, UInt};
 #[inline(always)]
 pub const unsafe fn transmute<const N: usize, const M: usize>(v: UInt<N>) -> UInt<M> {
     if N <= M {
-        UInt::from_digits(_transmute::<_, _, N>(v.digits()))
+        UInt::from_digits(_transmute::<N, M, N>(v.digits()))
     } else {
         debug_assert!(v.last_digit_index() < M);
         debug_assert!(v.bits() <= UInt::<M>::BITS);
-        UInt::from_digits(_transmute::<_, _, M>(v.digits()))
+        UInt::from_digits(_transmute::<N, M, M>(v.digits()))
     }
 }


### PR DESCRIPTION
Explicitly specify const generic parameters in _transmute calls to fix compilation errors with Rust 1.87, which does not support inference of const generics with `_`.

Changes:
- int/intrinsics/transmute.rs: Specify <N, M, N> and <N, M, M> explicitly
- uint/intrinsics/transmute.rs: Specify <N, M, N> and <N, M, M> explicitly

Add GitHub CI workflow:
- Test against Rust 1.87 (MSRV) and stable versions
- Lint checks (clippy, rustfmt)
- Documentation build with nightly
- Comprehensive feature matrix testing
- MSRV verification with cargo-msrv

This fixes the build error:
  error[E0658]: const arguments cannot yet be inferred with `_`

Closes #55.