### PR TITLE
Fix decimal hash to comply to hash contract

### DIFF
--- a/src/decimal/dec/impls/hash.rs
+++ b/src/decimal/dec/impls/hash.rs
@@ -7,6 +7,6 @@ impl<const N: usize> Hash for Decimal<N> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let normalized = self.reduce();
         normalized.digits.hash(state);
-        normalized.cb.hash(state);
+        normalized.fractional_digits_count().hash(state);
     }
 }

--- a/tests/decimal/common/hash.rs
+++ b/tests/decimal/common/hash.rs
@@ -45,6 +45,7 @@ macro_rules! test_impl {
     };
     (COMMON, $dec: ident, $D: ident) => {
         #[rstest(::trace)]
+        #[case($dec!(1), $dec!(1.1).floor())]
         #[case($dec!(1.1234), $dec!(1.1234000))]
         #[case($dec!(001.1234), $dec!(0001.1234))]
         #[case($dec!(1.1234000000), $dec!(1.1234000))]
@@ -74,6 +75,8 @@ macro_rules! test_impl {
     (UNSIGNED, $dec: ident, $D: ident) => {};
     (SIGNED, $dec: ident, $D: ident) => {
         #[rstest(::trace)]
+        #[case($dec!(0.00), $dec!(-0.000))]
+        #[case($dec!(-0.00), $dec!(0.000))]
         #[case($dec!(-0901300e-3), $dec!(-901.3))]
         #[case($dec!(-0.901300e+3), $dec!(-901.3))]
         fn test_hash_eq_signed(#[case] a: $D, #[case] b: $D) {
@@ -84,8 +87,6 @@ macro_rules! test_impl {
         #[rstest(::trace)]
         #[case($dec!(-0901300e-4), $dec!(-901.3))]
         #[case($dec!(-0.901300e+3), $dec!(-901.31))]
-        #[case($dec!(-0.00), $dec!(0.000))]
-        #[case($dec!(0.00), $dec!(-0.000))]
         fn test_hash_ne_signed(#[case] a: $D, #[case] b: $D) {
             assert_ne!(hash(&a), hash(&b));
         }

--- a/tests/decimal/common/hash.rs
+++ b/tests/decimal/common/hash.rs
@@ -88,6 +88,7 @@ macro_rules! test_impl {
         #[case($dec!(-0901300e-4), $dec!(-901.3))]
         #[case($dec!(-0.901300e+3), $dec!(-901.31))]
         fn test_hash_ne_signed(#[case] a: $D, #[case] b: $D) {
+            assert_ne!(a, b);
             assert_ne!(hash(&a), hash(&b));
         }
     };


### PR DESCRIPTION
Changes the hash of `Decimal` to not include the control block, see #59.