### PR TITLE
Fix: strip trailing fractional zeros on integral values during rounding

### DIFF
--- a/src/decimal/dec/round.rs
+++ b/src/decimal/dec/round.rs
@@ -1,5 +1,8 @@
 use crate::decimal::{
-    dec::math::{add::add, sub::sub},
+    dec::{
+        math::{add::add, sub::sub},
+        scale::reduce,
+    },
     Decimal,
     RoundingMode::*,
 };
@@ -50,7 +53,7 @@ pub(crate) const fn floor<const N: usize>(d: D<N>) -> D<N> {
     }
 
     if d.is_integral() {
-        d
+        reduce(d)
     } else {
         let rounded = d.with_rounding_mode(Down).round(0);
         if d.is_negative() {
@@ -68,7 +71,7 @@ pub(crate) const fn ceil<const N: usize>(d: D<N>) -> D<N> {
     }
 
     if d.is_integral() {
-        d
+        reduce(d)
     } else {
         let rounded = d.with_rounding_mode(Down).round(0);
         if d.is_negative() {

--- a/tests/decimal/common/extras/serde.rs
+++ b/tests/decimal/common/extras/serde.rs
@@ -137,6 +137,16 @@ macro_rules! test_impl {
 
         super::test_impl!(FROM INT:: $dec, $D, U8, U16, U32, U64);
         super::test_impl!(TRY FROM FLOAT:: $dec, $D, F32, F64);
+
+        #[rstest(::trace)]
+        fn test_serialize_floor_of_integral_mul_result() {
+            // Regression test: floor() on a product that is mathematically integral
+            // but retains trailing fractional zeros must serialize without a decimal
+            // point (e.g. "3", not "3.0").
+            let n = ($dec!(1.5) * $dec!(2)).floor();
+            let expected = serde_test::Token::Str("3");
+            serde_test::assert_tokens(&n, &[expected]);
+        }
     };
     (UNSIGNED:: 128, $dec: ident, $D: ident, THIS) => {
         super::test_impl!(UNSIGNED:: 128, $dec, $D);


### PR DESCRIPTION
When the input was already integral (e.g. 3.0 from 1.5 * 2), floor() and ceil() returned it unchanged, preserving the original scale. This caused serde to serialize "3.0" instead of "3".

Fix: return reduce(d) in the is_integral() fast path so trailing zeros are stripped and scale is normalized to 0.

Affected: both floor() and ceil(), provided a reproducible test.