### PR TITLE
fix(trivial): use existing type, match consistency

### DIFF
--- a/src/decimal/dec/extras/sqlx/pg.rs
+++ b/src/decimal/dec/extras/sqlx/pg.rs
@@ -48,7 +48,7 @@ impl<const N: usize> Decode<'_, Postgres> for D<N> {
             PgValueFormat::Binary => Ok(NBase::decode(value.as_bytes()?)?
                 .try_into()
                 .map_err(|e| pretty_error_msg(D::<N>::type_name(), e))?),
-            PgValueFormat::Text => Ok(value.as_str()?.parse::<Decimal<N>>()?),
+            PgValueFormat::Text => Ok(value.as_str()?.parse::<D<N>>()?),
         }
     }
 }


### PR DESCRIPTION
Since `type D<const N: usize>` already exists and is used in one of the match arms, the same type is referenced in the second match arm.